### PR TITLE
Set the right github org name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/fluture/fluture-hooks.git"
+    "url": "git://github.com/fluture-js/fluture-hooks.git"
   },
   "files": [
     "/index.js",


### PR DESCRIPTION
I noticed the current link didn't resolve, as part of a package.json analysis tool.