### PR TITLE
Fix an issue where applied ParallelHook doesn't always continue

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,9 +190,10 @@ export const sequential = m => m.hook;
 
 const hookAllReducer = (xs, x) => mappend(xs)(x);
 
-//# hookAll :: Array (Hook i (Future a b)) -> Hook i (Future a (Array b))
+//# hookAll :: Array (Hook (Future a b) c) -> Hook (Future a b) (Array c)
 //.
-//. Combines resources from many hooks into a single hook in parallel.
+//. Combines resources from many hooks into a single hook in parallel, given
+//. that the eventual consumption of this new hook will return a Future.
 //.
 //. `hookAll (hooks)` is the equivalent of
 //. `sequential (sequence (ParallelHook) (map (ParallelHook) (hooks)))` for all

--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ ParallelHook.prototype[$ap] = function(mf){
         action.cancel = rx._interpret(
           e => early(crash(e), action),
           x => early(reject(x), action),
-          x => early(resolve(x), action),
+          noop,
         );
         return action;
       },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "c8": "^6.0.1",
     "fluture": "^12.0.0",
-    "oletus": "^2.0.0",
+    "oletus": "^3.0.0",
     "rollup": "^1.21.4",
     "sanctuary-type-identifiers": "^2.0.1",
     "transcribe": "^1.1.1",

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -22,8 +22,8 @@ const effect = fl.value (id);
 
 const with42 = Hook.of (42);
 const with42p = ParallelHook.of (42);
-const mockAcquire = id => fl.attempt (() => ({id, disposed: false}));
-const mockDispose = resource => fl.attempt (() => { resource.disposed = true });
+const mockAcquire = id => fl.attempt (() => ({id, disposed: 0}));
+const mockDispose = resource => fl.attempt (() => { resource.disposed++ });
 const mockHook = hook (mockAcquire (1)) (mockDispose);
 const mockHook2 = acquire (mockAcquire (2));
 const mockParallelHook = ParallelHook (mockHook);
@@ -48,15 +48,15 @@ test ('assertions', () => {
 
   fl.value (eq (43)) (runParallel (fl.ap (with42p) (ParallelHook.of (inc))) (fl.resolve));
 
-  effect (runHook (mockHook) (compose (fl.resolve) (eq ({id: 1, disposed: false}))));
-  fl.value (eq ({id: 1, disposed: true})) (runHook (mockHook) (fl.resolve));
+  effect (runHook (mockHook) (compose (fl.resolve) (eq ({id: 1, disposed: 0}))));
+  fl.value (eq ({id: 1, disposed: 1})) (runHook (mockHook) (fl.resolve));
 
-  effect (runHook (mockHook2) (compose (fl.resolve) (eq ({id: 2, disposed: false}))));
-  fl.value (eq ({id: 2, disposed: false})) (runHook (mockHook2) (fl.resolve));
+  effect (runHook (mockHook2) (compose (fl.resolve) (eq ({id: 2, disposed: 0}))));
+  fl.value (eq ({id: 2, disposed: 0})) (runHook (mockHook2) (fl.resolve));
 
   eq (sequential (mockParallelHook)) (mockHook);
 
-  fl.value (eq ([{id: 1, disposed: true}, {id: 2, disposed: false}]))
+  fl.value (eq ([{id: 1, disposed: 1}, {id: 2, disposed: 0}]))
            (runHook (hookAll ([mockHook, mockHook2])) (fl.resolve));
 });
 
@@ -75,25 +75,25 @@ const mockHooks = [ hook (mockAcquire (1)) (mockDispose)
 test ('async assertions', () => Promise.all ([
   equivalence (runHook (hook (delay (mockAcquire (1))) (mockDisposeAsync))
                        (fl.resolve))
-              (fl.resolve ({id: 1, disposed: true})),
+              (fl.resolve ({id: 1, disposed: 1})),
 
   equivalence (runHook (hookAll (mockHooks)) (fl.resolve))
-              (fl.resolve ([ {id: 1, disposed: true}
-                           , {id: 2, disposed: true}
-                           , {id: 3, disposed: true}
-                           , {id: 4, disposed: true}
-                           , {id: 5, disposed: true}
-                           , {id: 6, disposed: true}
-                           , {id: 7, disposed: true}
-                           , {id: 8, disposed: true} ])),
+              (fl.resolve ([ {id: 1, disposed: 1}
+                           , {id: 2, disposed: 1}
+                           , {id: 3, disposed: 1}
+                           , {id: 4, disposed: 1}
+                           , {id: 5, disposed: 1}
+                           , {id: 6, disposed: 1}
+                           , {id: 7, disposed: 1}
+                           , {id: 8, disposed: 1} ])),
 
   fl.promise (runHook (hookAll (mockHooks))
-                      (compose (fl.resolve) (eq ([ {id: 1, disposed: false}
-                                                 , {id: 2, disposed: false}
-                                                 , {id: 3, disposed: false}
-                                                 , {id: 4, disposed: false}
-                                                 , {id: 5, disposed: false}
-                                                 , {id: 6, disposed: false}
-                                                 , {id: 7, disposed: false}
-                                                 , {id: 8, disposed: false} ])))),
+                      (compose (fl.resolve) (eq ([ {id: 1, disposed: 0}
+                                                 , {id: 2, disposed: 0}
+                                                 , {id: 3, disposed: 0}
+                                                 , {id: 4, disposed: 0}
+                                                 , {id: 5, disposed: 0}
+                                                 , {id: 6, disposed: 0}
+                                                 , {id: 7, disposed: 0}
+                                                 , {id: 8, disposed: 0} ])))),
 ]));

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -1,16 +1,15 @@
 import {deepStrictEqual} from 'assert';
-import {Future, attempt, value, resolve, map, ap, chain} from 'fluture/index.js';
-import {equivalence} from 'fluture/test/assertions.js';
+import * as fl from 'fluture/index.js';
+import {equivalence, equality as eq} from 'fluture/test/assertions.js';
 import identify from 'sanctuary-type-identifiers';
 import {Hook, hook, acquire, runHook, ParallelHook, sequential, hookAll} from '../index.js';
 import test from 'oletus'
 
-const crash = e => Future (() => { throw e });
+const crash = e => fl.Future (() => { throw e });
 
 const id = x => x;
 const inc = x => x + 1;
 const compose = f => g => x => f (g (x));
-const eq = a => b => { deepStrictEqual (a, b) };
 
 const assertType = name => x => {
   const t = identify.parse (identify (x));
@@ -19,12 +18,12 @@ const assertType = name => x => {
 }
 
 const runParallel = compose (runHook) (sequential);
-const effect = value (id);
+const effect = fl.value (id);
 
 const with42 = Hook.of (42);
 const with42p = ParallelHook.of (42);
-const mockAcquire = id => attempt (() => ({id, disposed: false}));
-const mockDispose = resource => attempt (() => { resource.disposed = true });
+const mockAcquire = id => fl.attempt (() => ({id, disposed: false}));
+const mockDispose = resource => fl.attempt (() => { resource.disposed = true });
 const mockHook = hook (mockAcquire (1)) (mockDispose);
 const mockHook2 = acquire (mockAcquire (2));
 const mockParallelHook = ParallelHook (mockHook);
@@ -40,23 +39,61 @@ test ('assertions', () => {
   assertType ('ParallelHook') (mockParallelHook);
 
   eq (runHook (with42) (id)) (42);
-  eq (runHook (map (inc) (with42)) (id)) (43);
-  eq (runHook (ap (with42) (Hook.of (inc))) (id)) (43);
-  eq (runHook (chain (Hook.of) (with42)) (id)) (42);
+  eq (runHook (fl.map (inc) (with42)) (id)) (43);
+  eq (runHook (fl.ap (with42) (Hook.of (inc))) (id)) (43);
+  eq (runHook (fl.chain (Hook.of) (with42)) (id)) (42);
 
   eq (runParallel (with42p) (id)) (42);
-  eq (runParallel (map (inc) (with42p)) (id)) (43);
+  eq (runParallel (fl.map (inc) (with42p)) (id)) (43);
 
-  value (eq (43)) (runParallel (ap (with42p) (ParallelHook.of (inc))) (resolve));
+  fl.value (eq (43)) (runParallel (fl.ap (with42p) (ParallelHook.of (inc))) (fl.resolve));
 
-  effect (runHook (mockHook) (compose (resolve) (eq ({id: 1, disposed: false}))));
-  value (eq ({id: 1, disposed: true})) (runHook (mockHook) (resolve));
+  effect (runHook (mockHook) (compose (fl.resolve) (eq ({id: 1, disposed: false}))));
+  fl.value (eq ({id: 1, disposed: true})) (runHook (mockHook) (fl.resolve));
 
-  effect (runHook (mockHook2) (compose (resolve) (eq ({id: 2, disposed: false}))));
-  value (eq ({id: 2, disposed: false})) (runHook (mockHook2) (resolve));
+  effect (runHook (mockHook2) (compose (fl.resolve) (eq ({id: 2, disposed: false}))));
+  fl.value (eq ({id: 2, disposed: false})) (runHook (mockHook2) (fl.resolve));
 
   eq (sequential (mockParallelHook)) (mockHook);
 
-  value (eq ([{id: 1, disposed: true}, {id: 2, disposed: false}]))
-        (runHook (hookAll ([mockHook, mockHook2])) (resolve));
+  fl.value (eq ([{id: 1, disposed: true}, {id: 2, disposed: false}]))
+           (runHook (hookAll ([mockHook, mockHook2])) (fl.resolve));
 });
+
+const delay = fl.chain (fl.after (10));
+const mockDisposeAsync = compose (delay) (mockDispose);
+
+const mockHooks = [ hook (mockAcquire (1)) (mockDispose)
+                  , hook (delay (mockAcquire (2))) (mockDispose)
+                  , hook (mockAcquire (3)) (mockDisposeAsync)
+                  , hook (delay (mockAcquire (4))) (mockDisposeAsync)
+                  , hook (mockAcquire (5)) (mockDispose)
+                  , hook (delay (mockAcquire (6))) (mockDispose)
+                  , hook (mockAcquire (7)) (mockDisposeAsync)
+                  , hook (delay (mockAcquire (8))) (mockDisposeAsync) ];
+
+test ('async assertions', () => Promise.all ([
+  equivalence (runHook (hook (delay (mockAcquire (1))) (mockDisposeAsync))
+                       (fl.resolve))
+              (fl.resolve ({id: 1, disposed: true})),
+
+  equivalence (runHook (hookAll (mockHooks)) (fl.resolve))
+              (fl.resolve ([ {id: 1, disposed: true}
+                           , {id: 2, disposed: true}
+                           , {id: 3, disposed: true}
+                           , {id: 4, disposed: true}
+                           , {id: 5, disposed: true}
+                           , {id: 6, disposed: true}
+                           , {id: 7, disposed: true}
+                           , {id: 8, disposed: true} ])),
+
+  fl.promise (runHook (hookAll (mockHooks))
+                      (compose (fl.resolve) (eq ([ {id: 1, disposed: false}
+                                                 , {id: 2, disposed: false}
+                                                 , {id: 3, disposed: false}
+                                                 , {id: 4, disposed: false}
+                                                 , {id: 5, disposed: false}
+                                                 , {id: 6, disposed: false}
+                                                 , {id: 7, disposed: false}
+                                                 , {id: 8, disposed: false} ])))),
+]));


### PR DESCRIPTION
Another crack at what I tried to do with #11, but this time I took a test-based approach.

- I started by adding regression tests against the regressions I managed to introduce in #11.
- Then I improved the tests by asserting that resources are not doubly disposed. This exposed a bug which I fixed.
- Then I refactored some of the testing code to be less verbose.
- I also noticed that the documented signature for `hookAll` is *all wrong*, and I fixed that.
- Finally I got to the problem at hand. Details below.

*:warning: As opposed to the approach I was taking in #11, I intend to release this as version `2.0.1` first. The primary reason is that my testing tools have been updated on the master branch, allowing me to write reliable async tests. I will then take the changes to the code I made on master and backport them to `1.x`, not bringing along the tests (because the `1.x` branch cannot support these types of tests) and release it as `1.0.4`.*

----

The fix proposed in #6 actually led to a new issue where
in specific circumstances, a Future would be left forever
pending (`never`) after resource disposal had completed.

The new solution solves the same problem that #6 did, but
in a different way. Now, instead of using a custom
transformation on top of the undocumented transform API,
we use a custom Future using the undocumented Future class.

This new solution takes many more of the possible code paths
into account, now rigorously tested using 256 assertions
generated using a possibility matrix to brute-force all
thinkable input scenarios.