### PR TITLE
Add support for sanctuary-type-identifiers 3

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,10 @@ export function Hook(run) {
 HookFromCallback.prototype = Object.create (Hook.prototype);
 
 Hook['@@type'] = 'fluture/Hook@1';
+Hook.constructor = {prototype: Hook};
 Hook.of = Hook[$of] = x => Hook (Callback.of (x));
+
+Hook.prototype['@@type'] = Hook['@@type'];
 
 Hook.prototype[$ap] = function(mf) {
   return Hook (Callback.ap (mf.run) (this.run));
@@ -137,7 +140,10 @@ export function ParallelHook(hook) {
 ParallelHookFromHook.prototype = Object.create (ParallelHook.prototype);
 
 ParallelHook['@@type'] = 'fluture/ParallelHook@1';
+ParallelHook.constructor = {prototype: ParallelHook};
 ParallelHook.of = ParallelHook[$of] = x => ParallelHook (pure (Hook) (x));
+
+ParallelHook.prototype['@@type'] = ParallelHook['@@type'];
 
 ParallelHook.prototype[$map] = function(f) {
   return ParallelHook (map (f) (this.hook));

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "oletus": "^3.0.0",
     "rollup": "^2.0.0",
     "sanctuary-scripts": "^4.0.0",
-    "sanctuary-type-identifiers": "^2.0.1"
+    "sanctuary-type-identifiers": "^3.0.0"
   }
 }


### PR DESCRIPTION
I missed this one. Found it while setting up a new project that uses Sanctuary Type Identifiers 3 to define Sanctuary Def types.